### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run Hardhat Tests in Docker
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/evgeny-baranov/blockchain-test/security/code-scanning/1](https://github.com/evgeny-baranov/blockchain-test/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions for the `GITHUB_TOKEN`, limiting them to the least privilege required. Since the workflow does not appear to require write access, the permissions can be set to `contents: read`. This change ensures that the workflow adheres to security best practices without altering its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
